### PR TITLE
docs: standardize question punctuation in hosting setup

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -30,9 +30,9 @@ firebase init
 # - Hosting: Configure files for Firebase Hosting
 # - Use an existing project
 # - Seleccionar tu proyecto "fantasy-tales-universe"
-# - ¿What do you want to use as your public directory? dist
-# - ¿Configure as a single-page app (rewrite all urls to /index.html)? Yes
-# - ¿Set up automatic builds and deploys with GitHub? No
+# - What do you want to use as your public directory? dist
+# - Configure as a single-page app (rewrite all urls to /index.html)? Yes
+# - Set up automatic builds and deploys with GitHub? No
 ```
 
 ## 4. Configuración del archivo firebase.json


### PR DESCRIPTION
## Summary
- remove Spanish-style opening question marks from Firebase Hosting prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49f67b4f483308a7d1e6e2f0ebcb7