### PR TITLE
refactor: use vitest mocked types in tests

### DIFF
--- a/src/components/auth/LoginModal.test.tsx
+++ b/src/components/auth/LoginModal.test.tsx
@@ -16,7 +16,7 @@ describe('LoginModal', () => {
   const mockOnClose = vi.fn();
 
   beforeEach(() => {
-    (useAuth as jest.Mock).mockReturnValue({
+    vi.mocked(useAuth).mockReturnValue({
       signInWithEmail: mockSignInWithEmail,
       signUpWithEmail: mockSignUpWithEmail,
       signInWithGoogle: mockSignInWithGoogle,

--- a/src/components/auth/ProtectedRoute.test.tsx
+++ b/src/components/auth/ProtectedRoute.test.tsx
@@ -29,7 +29,7 @@ describe('ProtectedRoute', () => {
   });
 
   test('muestra el spinner de carga cuando está cargando', () => {
-    (useAuth as jest.Mock).mockReturnValue({
+    vi.mocked(useAuth).mockReturnValue({
       currentUser: null,
       loading: true,
     });
@@ -47,7 +47,7 @@ describe('ProtectedRoute', () => {
   });
 
   test('redirige a /inicio cuando no hay usuario autenticado', () => {
-    (useAuth as jest.Mock).mockReturnValue({
+    vi.mocked(useAuth).mockReturnValue({
       currentUser: null,
       loading: false,
     });
@@ -65,7 +65,7 @@ describe('ProtectedRoute', () => {
   });
 
   test('redirige a la ruta especificada cuando no hay usuario autenticado', () => {
-    (useAuth as jest.Mock).mockReturnValue({
+    vi.mocked(useAuth).mockReturnValue({
       currentUser: null,
       loading: false,
     });
@@ -82,7 +82,7 @@ describe('ProtectedRoute', () => {
   });
 
   test('renderiza el contenido cuando hay un usuario autenticado', () => {
-    (useAuth as jest.Mock).mockReturnValue({
+    vi.mocked(useAuth).mockReturnValue({
       currentUser: { email: 'test@example.com' },
       loading: false,
     });

--- a/src/contexts/AuthContext.test.tsx
+++ b/src/contexts/AuthContext.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { vi } from 'vitest';
 import { AuthProvider, useAuth } from './AuthContext';
 import { 
   signInWithEmailAndPassword,
@@ -96,7 +96,7 @@ describe('AuthContext', () => {
   });
 
   test('provee el usuario actual cuando está autenticado', async () => {
-    (onAuthStateChanged as jest.Mock).mockImplementation((auth, callback) => {
+    vi.mocked(onAuthStateChanged).mockImplementation((auth, callback) => {
       callback(mockUser);
       return () => {};
     });
@@ -113,7 +113,7 @@ describe('AuthContext', () => {
   });
 
   test('maneja el inicio de sesión con email correctamente', async () => {
-    (signInWithEmailAndPassword as jest.Mock).mockResolvedValueOnce({
+    vi.mocked(signInWithEmailAndPassword).mockResolvedValueOnce({
       user: mockUser
     });
 
@@ -135,10 +135,10 @@ describe('AuthContext', () => {
   });
 
   test('maneja el registro con email correctamente', async () => {
-    (createUserWithEmailAndPassword as jest.Mock).mockResolvedValueOnce({
+    vi.mocked(createUserWithEmailAndPassword).mockResolvedValueOnce({
       user: mockUser
     });
-    (setDoc as jest.Mock).mockResolvedValueOnce({});
+    vi.mocked(setDoc).mockResolvedValueOnce({});
 
     render(
       <AuthProvider>
@@ -160,11 +160,11 @@ describe('AuthContext', () => {
 
   test('maneja el inicio de sesión con Google correctamente', async () => {
     const mockProvider = new GoogleAuthProvider();
-    (signInWithPopup as jest.Mock).mockResolvedValueOnce({
+    vi.mocked(signInWithPopup).mockResolvedValueOnce({
       user: mockUser
     });
-    (doc as jest.Mock).mockReturnValue('mockedDocRef');
-    (setDoc as jest.Mock).mockResolvedValueOnce({});
+    vi.mocked(doc).mockReturnValue('mockedDocRef');
+    vi.mocked(setDoc).mockResolvedValueOnce({});
 
     render(
       <AuthProvider>
@@ -191,7 +191,7 @@ describe('AuthContext', () => {
   });
 
   test('maneja el cierre de sesión correctamente', async () => {
-    (signOut as jest.Mock).mockResolvedValueOnce({});
+    vi.mocked(signOut).mockResolvedValueOnce({});
 
     render(
       <AuthProvider>


### PR DESCRIPTION
## Summary
- refactor auth-related tests to use `vi.mocked` instead of `jest.Mock`
- ensure tests import `vi` from vitest

## Testing
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68a49fa9884883308f6c7270111270e6